### PR TITLE
Make Sauce metadata handling more robust

### DIFF
--- a/custom_commands/sauceEnd.js
+++ b/custom_commands/sauceEnd.js
@@ -28,7 +28,6 @@ exports.command = function(result) {
         saucelabs.updateJob(sessionid, {
             passed: this.currentTest.results.failed === 0,
             name: jobName,
-            proxy: "https://fakemistakeshake.com:4dede44"
         }, function(err, res) {
             if(err){
                 handle_error(err);


### PR DESCRIPTION
If errors occur when updating the Sauce Labs REST API, they're
silently swallowed.

Furthermore, if errors occur during parsing of `sauceEnd.js`, they
_also_ fail silently, leading users unsure of what's going on.

This change adds error handling which prints to `stderr` and
informs the user on `stdout` of a problem.

It also moves the Jenkins plugin log line above the REST API call,
so that this line is still printed if the API has issues.